### PR TITLE
Removed encrypted from ocs-storagecluster-ceph-rbd

### DIFF
--- a/openshift_storage_odf_apps.md
+++ b/openshift_storage_odf_apps.md
@@ -34,7 +34,7 @@ After you install the OpenShift Data Foundation add-on for your {{site.data.keyw
     ```sh
     NAME                   PROVISIONER            RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
     Immediate              true                   9m19s
-    ocs-storagecluster-ceph-rbd-encrypted         openshift-storage.rbd.csi.ceph.com      Delete          Immediate              false                  9m19s
+    ocs-storagecluster-ceph-rbd                   openshift-storage.rbd.csi.ceph.com      Delete          Immediate              false                  9m19s
     ocs-storagecluster-ceph-rgw                   openshift-storage.ceph.rook.io/bucket   Delete          Immediate              false                  18m
     ocs-storagecluster-cephfs                     openshift-storage.cephfs.csi.ceph.com   Delete          Immediate              true                   10m
     openshift-storage.noobaa.io                   openshift-storage.noobaa.io/obc         Delete          Immediate              false                  6m32s


### PR DESCRIPTION
In my last deployment, I could only find the storage class `ocs-storagecluster-ceph-rbd` instead of `ocs-storagecluster-ceph-rbd-encrypted`.