### PR TITLE
Fix invalid image pull secret type

### DIFF
--- a/registry.md
+++ b/registry.md
@@ -431,7 +431,7 @@ To use the internal registry, set up a public route to access the registry. Then
         - `--docker-email`: If you have one, enter your Docker email address. If you don't, enter a fictional email address, such as `a@b.c`. This email is required to create a Kubernetes secret, but is not used after creation.
 
         ```sh
-        oc create secret image-registry internal-registry --namespace default --docker-server image-registry-openshift-image-registry.<cluster_name>-<ID_string>.<region>.containers.appdomain.cloud:5000 --docker-username serviceaccount --docker-password <eyJ...> --docker-email a@b.c
+        oc create secret docker-registry internal-registry --namespace default --docker-server image-registry-openshift-image-registry.<cluster_name>-<ID_string>.<region>.containers.appdomain.cloud:5000 --docker-username serviceaccount --docker-password <eyJ...> --docker-email a@b.c
         ```
         {: pre}
 


### PR DESCRIPTION
Thanks for taking the time to contribute to the IBM Cloud docs! After you open your pull request, a maintainer should review it soon.

We don't merge changes directly in this repository because content is not published from here. However, we'll incorporate any changes in our upstream repository so that they're reflected in the docs.

### Description

<!--- Replace this text with a summary of the changes in this pull request. Include why the changes are needed and context about the changes. --->

`oc create secret image-registry` isn't a valid command. The correct command to create an image pull secret is `oc create secret docker-registry`.

###  Any other comments?

<!-- Add additional information or screenshots that you think we need.-->

There are other secret create commands in this topic that correctly use the `docker-registry` type.

See https://docs.openshift.com/container-platform/4.16/cli_reference/openshift_cli/developer-cli-commands.html#oc-create-secret-docker-registry

---

### For reviewers (This section is only for IBMers)

You can't merge pull requests here.

- If you can incorporate these changes, copy them to your GitHub Enterprise repo. Leave a comment and close the pull request.
- If you can't accept the changes, leave information about why, and close the pull request.

If you don't have permission to close the request, ask for help in the IBM Cloud \#docs Slack channel.
