### PR TITLE
Removing  optional IBMCLOUD_VPC_ENDPOINT env

### DIFF
--- a/confidential-containers.md
+++ b/confidential-containers.md
@@ -368,7 +368,6 @@ After the Operator is installed, create ConfigMaps to allow Kata to handle workl
       IBMCLOUD_PODVM_INSTANCE_PROFILE_NAME: "bx3dc-2x10"
       IBMCLOUD_RESOURCE_GROUP_ID: "$(ibmcloud is vpc "$VPC_ID" -json | jq -r .resource_group.id)"
       IBMCLOUD_SSH_KEY_ID: "$SSH_KEY_ID"
-      IBMCLOUD_VPC_ENDPOINT: "https://us-east.iaas.cloud.ibm.com/v1"
       IBMCLOUD_VPC_ID: "$VPC_ID"
       IBMCLOUD_VPC_SG_ID: "$(ibmcloud ks security-group ls --cluster $CLUSTER_NAME -json | jq -r '.[] | select(.type == "cluster") | .id')"
       CLOUD_CONFIG_VERIFY: "false"


### PR DESCRIPTION


### Description

Remove IBMCLOUD_VPC_ENDPOINT from documentation to prevent configuration errors. The cloud-api-adaptor now automatically derives and sets the correct VPC Service URL based on the cluster node label topology.kubernetes.io/region
 The corresponding code is here --> https://github.com/confidential-containers/cloud-api-adaptor/blob/main/src/cloud-providers/ibmcloud/provider.go#L105
###  Any other comments?

<!-- Add additional information or screenshots that you think we need.-->

---

### For reviewers (This section is only for IBMers)

You can't merge pull requests here.

- If you can incorporate these changes, copy them to your GitHub Enterprise repo. Leave a comment and close the pull request.
- If you can't accept the changes, leave information about why, and close the pull request.

If you don't have permission to close the request, ask for help in the IBM Cloud \#docs Slack channel.
